### PR TITLE
Add in error throw for null/undefined input

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ mOcKiNgCaSe('42foo!bar');
 mOcKiNgCaSe(['foo','bar']);
 //=> 'fOoBaR';
 
+mOcKiNgCaSe(undefined);
+//=> Error "An input is required
+
 mOcKiNgCaSe.log('foo bar');
 // console.log('fOo bAr');
 ```

--- a/index.js
+++ b/index.js
@@ -7,10 +7,15 @@
  * @param {boolean} options.random=false - using random for converting
  * @returns {string} string in mOcKiNgCaSe
  */
-function mOcKiNgCaSe(input, options) {
+function mOcKiNgCaSe(input = "", options) {
   options = Object.assign({
     random: false,
   }, options);
+
+  //First, check to see that an input is recieved, and throw error if not
+  if(input === ""){
+    throw new Error("An input is required")
+  }
 
   if (isArrayOfStrings(input)) input = input.join('');
 

--- a/mockingcase.test.js
+++ b/mockingcase.test.js
@@ -24,6 +24,14 @@ describe('mockingcase', () => {
     });
   });
 
+  describe('empty input', () => {
+    test("If the input is left blank, an error should be thrown", () => {
+      const input = "";
+      const expectedOutput = undefined;
+      expect(() => mOcKiNgCaSe(input).toThrow());
+    })
+  })
+
   describe('input as array', () => {
     test('If input is an array of strings, it should return the mOcKiNgCaSe version of the string formed by the array elements.', () => {
       const input = ['foo', 'bar'];


### PR DESCRIPTION
I added in a small check for missing input. It just throws an error if the input isn't defined. Could also just return undefined / empty string instead.