### PR TITLE
Add support for options in `toMockingCase()` (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ mOcKiNgCaSe.overrideString();
 
 'foo_bar'.toMockingCase();
 //=> 'fOo_bAr'
+
+'foo_bar'.toMockingCase({firstUpper: true});
+//=> 'FoO_BaR'
 ```
 
 ## API
@@ -109,13 +112,20 @@ Creates `String.prototype.toMockingCase()`.
 
 <a name="String.prototype.toMockingCase"></a>
 
-### String.prototype.toMockingCase() ⇒ <code>string</code>
+### String.prototype.toMockingCase([options]) ⇒ <code>string</code>
 Converts `this` string to mOcKiNgCaSe.
 
 **NOTE**: this function is created by invoking `mOcKiNgCaSe.overrideString()`.
 
 **Kind**: prototype  
 **Returns**: <code>string</code> - local string in mOcKiNgCaSe
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [options] | <code>object</code> | <code>{random: false, onlyLetters: false, firstUpper: false}</code> | Conversion options |
+| options.random | <code>boolean</code> | <code>false</code> | If case conversion should be randomized |
+| options.onlyLetters | <code>boolean</code> | <code>false</code> | If non letters characters should be removed |
+| options.firstUpper | <code>boolean</code> | <code>false</code> | If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with `options.random`, the first letter of the random string will be capitalized |
 
 <hr>
 

--- a/index.js
+++ b/index.js
@@ -71,10 +71,16 @@ mOcKiNgCaSe.overrideString = () => {
 
   /**
     * Converts this string to mOcKiNgCaSe.
+    * @param {object} [options={random: false}] Options for converting.
+    * @param {boolean} options.random=false - If case conversion should be randomized.
+    * @param {boolean} options.onlyLetters=false - If non letters characters should be removed.
+    * @param {boolean} options.firstUpper=false - If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE).
+    * When combined with `options.random`, the first letter of the random string will be capitalized.
+    * @returns {string} string in mOcKiNgCaSe
     * @see mOcKiNgCaSe
     */
-  String.prototype.toMockingCase = function () {
-    return mOcKiNgCaSe(this);
+  String.prototype.toMockingCase = function (options) {
+    return mOcKiNgCaSe(this, options);
   };
 
   return mOcKiNgCaSe;

--- a/mockingcase.test.js
+++ b/mockingcase.test.js
@@ -96,6 +96,15 @@ describe('mockingcase', () => {
       expect(input.toMockingCase()).toEqual(expectedOutput);
     });
 
+    test("Does not ignore options", () => {
+      const input = "hello world";
+      const options = {
+        firstUpper: true,
+      };
+      const expectedOutput = mOcKiNgCaSe(input, options);
+      expect(input.toMockingCase(options)).toMatch(expectedOutput);
+    });
+
     test("If the string is left blank, an error should be thrown", () => {
       const input = "";
       expect(() => input.toMockingCase().toThrow());


### PR DESCRIPTION
This PR aims to resolve issue #35.

There is now the option to pass in an `options` object into `toMockingCase()` just like you could if you called `mOcKiNgCaSe` normally.

Additionally, I added a quick test to check whether the options array actually gets used. I don't think it is necessary to check all of the possible options again.

> Also better to use arrow function for it.

I think this is one of the use cases where arrow functions don't work out/don't make sense, since we're actually relying on the lexical `this`. However, I would be curious to hear suggestions if anybody has any ideas/inputs.
