### PR TITLE
Feature/specify letters conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ mOcKiNgCaSe('foo', {firstUpper: true, random: true});
 //=> 'FOo'
 //=> 'FoO'
 //=> 'FOO'
+
+mOcKiNgCaSe('abcdef', {upper: \[bdf]\});
+//=> 'aBcDeF'
+
+mOcKiNgCaSe('ABCDEF', {lower: 'bcd'});
+//=> 'AbcdEf'
 ```
 
 ## API
@@ -86,6 +92,8 @@ Converts the input string(s) to mOcKiNgCaSe.
 | options.random | <code>boolean</code> | <code>false</code> | If case conversion should be randomized |
 | options.onlyLetters | <code>boolean</code> | <code>false</code> | If non letters characters should be removed |
 | options.firstUpper | <code>boolean</code> | <code>false</code> | If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with `options.random`, the first letter of the random string will be capitalized |
+| options.upper | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to uppercase |
+| options.lower | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to lowercase |
 
 ```js
 mOcKiNgCaSe('foo-bar');
@@ -111,6 +119,12 @@ mOcKiNgCaSe('a13%$a', {onlyLetters: true});
 
 mOcKiNgCaSe('foo bar', {firstUpper: true});
 //=> 'FoO BaR'
+
+mOcKiNgCaSe('foo bar', {firstUpper: true, lower: /[fb]/});
+//=> 'foO baR'
+
+mOcKiNgCaSe('foo bar', {firstUpper: true, upper: /[oa]/});
+//=> 'FOO BAR'
 
 mOcKiNgCaSe('foo', {firstUpper: true, random: true});
 //=> 'Foo'
@@ -162,6 +176,8 @@ Converts `this` string to mOcKiNgCaSe.
 | options.random | <code>boolean</code> | <code>false</code> | If case conversion should be randomized |
 | options.onlyLetters | <code>boolean</code> | <code>false</code> | If non letters characters should be removed |
 | options.firstUpper | <code>boolean</code> | <code>false</code> | If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with `options.random`, the first letter of the random string will be capitalized |
+| options.upper | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to uppercase |
+| options.lower | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to lowercase |
 
 ```js
 'foo_bar'.toMockingCase();
@@ -186,6 +202,8 @@ Outputs a mOcKiNgCaSe with default options.
 | defaultOptions.random | <code>boolean</code> | <code>false</code> | If case conversion should be randomized |
 | defaultOptions.onlyLetters | <code>boolean</code> | <code>false</code> | If non letters characters should be removed |
 | defaultOptions.firstUpper | <code>boolean</code> | <code>false</code> | If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with `options.random`, the first letter of the random string will be capitalized |
+| options.upper | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to uppercase |
+| options.lower | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to lowercase |
 
 ```js
 const mOcKiNgCaSe = require('@strdr4605/mockingcase').config({onlyLetters: true, firstUpper: true});
@@ -213,6 +231,8 @@ Outputs a message to the console in mOcKiNgCaSe.
 | options.random | <code>boolean</code> | <code>false</code> | If case conversion should be randomized |
 | options.onlyLetters | <code>boolean</code> | <code>false</code> | If non letters characters should be removed |
 | options.firstUpper | <code>boolean</code> | <code>false</code> | If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with `options.random`, the first letter of the random string will be capitalized |
+| options.upper | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to uppercase |
+| options.lower | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to lowercase |
 
 ```js
 mOcKiNgCaSe.log('foo bar');
@@ -234,6 +254,8 @@ Overrides the console.log input annd prints it in the mOcKiNgCaSe.
 | options.random | <code>boolean</code> | <code>false</code> | If case conversion should be randomized |
 | options.onlyLetters | <code>boolean</code> | <code>false</code> | If non letters characters should be removed |
 | options.firstUpper | <code>boolean</code> | <code>false</code> | If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with `options.random`, the first letter of the random string will be capitalized |
+| options.upper | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to uppercase |
+| options.lower | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to lowercase |
 
 ```js
 const mOcKiNgCaSe = require('@strdr4605/mockingcase').overrideConsole();

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,8 @@ declare module "mockingcase" {
     random?: boolean;
     onlyLetters?: boolean;
     firstUpper?: boolean;
+    upper?: string | object;
+    lower?: string | object;
   }
 
   export = mockingcase;

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,8 +7,8 @@ declare module "mockingcase" {
     random?: boolean;
     onlyLetters?: boolean;
     firstUpper?: boolean;
-    upper?: string | object;
-    lower?: string | object;
+    upper?: string | RegExp;
+    lower?: string | RegExp;
   }
 
   export = mockingcase;

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@
  * @param {boolean} options.random=false - If case conversion should be randomized.
  * @param {boolean} options.onlyLetters=false - If non letters characters should be removed.
  * @param {boolean} options.firstUpper=false - If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE).
- * @param {(string | RegExp)} options.upper=null
- * @param {(string | RegExp)} options.lower=null
+ * @param {(string | RegExp)} options.upper=null - matched RegExp guarenteed to be upper cased
+ * @param {(string | RegExp)} options.lower=null - matched RegExp guarenteed to be lower cased
  * When combined with `options.random`, the first letter of the random string will be capitalized.
  * @returns {string} string in mOcKiNgCaSe
  */
@@ -43,13 +43,22 @@ function mOcKiNgCaSe(input = "", options) {
     if (options.firstUpper) {
       input = input[0].toUpperCase() + input.slice(1);
     }
-    return input;
+  } else if (options.firstUpper) {
+    input = convert(input, (str, i) => i % 2 === 0);
+  } else {
+    // Default to making the odd positioned characters upper case
+    input = convert(input, (str, i) => i % 2 === 1);
   }
 
-  if (options.firstUpper) {
-    return convert(input, (str, i) => i % 2 === 0);
+  if (options.upper) {
+    input = convertToSpecificCase(input, options.upper, "upper");
   }
-  return convert(input, (str, i) => i % 2 === 1);
+
+  if (options.lower) {
+    input = convertToSpecificCase(input, options.lower, "lower");
+  }
+
+  return input;
 }
 
 /**
@@ -140,6 +149,29 @@ function isArrayOfStrings(input) {
  */
 function randomCase(input) {
   return convert(input, () => Math.round(Math.random()));
+}
+
+/**
+ * Converts matched letters to a specified case
+ * @param {string} input - string to convert
+ * @param {(string | RegExp)} regex - use to match letters you want to convert
+ * @caseType {string} caseType - the case type
+ * @return the given input with match letters to the  case type determined
+ */
+function convertToSpecificCase(input, regex, caseType) {
+  if (caseType !== "lower" && caseType !== "upper") {
+    throw new Error(`casetype type must be 'lower' or 'upper'`);
+  }
+  if (typeof regex !== "string" && !(regex instanceof RegExp)) {
+    throw TypeError(
+      `options.${caseType}: Expected string or RegExp but got "${typeof regex}"`
+    );
+  }
+  regex = new RegExp(regex, "gi");
+  if (caseType === "upper") {
+    return input.replace(regex, str => str.toUpperCase());
+  }
+  return input.replace(regex, str => str.toLowerCase());
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@
  * @param {boolean} options.random=false - If case conversion should be randomized.
  * @param {boolean} options.onlyLetters=false - If non letters characters should be removed.
  * @param {boolean} options.firstUpper=false - If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE).
+ * @param {(string | RegExp)} options.upper=null
+ * @param {(string | RegExp)} options.lower=null
  * When combined with `options.random`, the first letter of the random string will be capitalized.
  * @returns {string} string in mOcKiNgCaSe
  */
@@ -14,6 +16,8 @@ function mOcKiNgCaSe(input = "", options) {
       random: false,
       onlyLetters: false,
       firstUpper: false,
+      upper: null,
+      lower: null,
     },
     options,
   );

--- a/index.js
+++ b/index.js
@@ -50,12 +50,12 @@ function mOcKiNgCaSe(input = "", options) {
     input = convert(input, (str, i) => i % 2 === 1);
   }
 
-  if (options.upper) {
-    input = convertToSpecificCase(input, options.upper, "upper");
+  if (options.lower) {
+    input = convertToSpecificCase(input, options.lower, str => str.toLowerCase());
   }
 
-  if (options.lower) {
-    input = convertToSpecificCase(input, options.lower, "lower");
+  if (options.upper) {
+    input = convertToSpecificCase(input, options.upper, str => str.toUpperCase());
   }
 
   return input;
@@ -96,6 +96,8 @@ mOcKiNgCaSe.overrideString = () => {
    * @param {boolean} options.random=false - If case conversion should be randomized.
    * @param {boolean} options.onlyLetters=false - If non letters characters should be removed.
    * @param {boolean} options.firstUpper=false - If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE).
+   * @param {(string | RegExp)} options.upper=null - matched RegExp guarenteed to be upper cased
+   * @param {(string | RegExp)} options.lower=null - matched RegExp guarenteed to be lower cased
    * When combined with `options.random`, the first letter of the random string will be capitalized.
    * @returns {string} string in mOcKiNgCaSe
    * @see mOcKiNgCaSe
@@ -113,6 +115,8 @@ mOcKiNgCaSe.overrideString = () => {
  * @param {boolean} options.random=false - If case conversion should be randomized.
  * @param {boolean} options.onlyLetters=false - If non letters characters should be removed.
  * @param {boolean} options.firstUpper=false - If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE).
+ * @param {(string | RegExp)} options.upper=null - matched RegExp guarenteed to be upper cased
+ * @param {(string | RegExp)} options.lower=null - matched RegExp guarenteed to be lower cased
  * When combined with `options.random`, the first letter of the random string will be capitalized.
  * @returns {function} mOcKiNgCaSe function
  * @see mOcKiNgCaSe
@@ -155,23 +159,15 @@ function randomCase(input) {
  * Converts matched letters to a specified case
  * @param {string} input - string to convert
  * @param {(string | RegExp)} regex - use to match letters you want to convert
- * @caseType {string} caseType - the case type
- * @return the given input with match letters to the  case type determined
+ * @param {function} caseReplacer - a function that changes the letter's case
+ * @return {string} given input with match letters to the  case type determined
  */
-function convertToSpecificCase(input, regex, caseType) {
-  if (caseType !== "lower" && caseType !== "upper") {
-    throw new Error(`casetype type must be 'lower' or 'upper'`);
-  }
+function convertToSpecificCase(input, regex, caseReplacer) {
   if (typeof regex !== "string" && !(regex instanceof RegExp)) {
-    throw TypeError(
-      `options.${caseType}: Expected string or RegExp but got "${typeof regex}"`
-    );
+    throw TypeError(`Expected string or RegExp but got "${typeof regex}"`);
   }
   regex = new RegExp(regex, "gi");
-  if (caseType === "upper") {
-    return input.replace(regex, str => str.toUpperCase());
-  }
-  return input.replace(regex, str => str.toLowerCase());
+  return input.replace(regex, caseReplacer);
 }
 
 /**

--- a/mockingcase.test.js
+++ b/mockingcase.test.js
@@ -227,7 +227,7 @@ describe("mockingcase", () => {
     const capitalizeInput = "Hello World";
     const upperCaseInput = "HELLO WORLD";
 
-    test("it should make match substring upper case", () => {
+    test("Should make match substring upper case", () => {
       const expectedOutput = "hElLo WORLd";
       const options = {
         upper: "worl",
@@ -240,7 +240,7 @@ describe("mockingcase", () => {
       expect(resultOutput).toStrictEqual(expectedOutput);
     });
 
-    test("it should make matched letters upper case", () => {
+    test("Should make matched letters upper case", () => {
       const expectedOutput = "hELLO WORLd";
       const options = {
         upper: "[lwro]",
@@ -253,7 +253,7 @@ describe("mockingcase", () => {
       expect(resultOutput).toStrictEqual(expectedOutput);
     });
 
-    test("it should keep string as default since substring does not match", () => {
+    test("Should keep string as default since substring does not match", () => {
       const expectedOutput = "hElLo wOrLd";
       const options = {
         upper: "ohd",
@@ -272,7 +272,7 @@ describe("mockingcase", () => {
     const capitalizeInput = "Hello World";
     const upperCaseInput = "HELLO WORLD";
 
-    test("it should guarantee matched substring is upper case", () => {
+    test("Should guarantee matched substring is upper case", () => {
       const expectedOutput = "hElLo WORLd";
       const options = {
         upper: /worl/,
@@ -285,7 +285,7 @@ describe("mockingcase", () => {
       expect(resultOutput).toStrictEqual(expectedOutput);
     });
 
-    test("it should guarantee all matched letters are upper case", () => {
+    test("Should guarantee all matched letters are upper case", () => {
       const expectedOutput = "hELLO WORLd";
       const options = {
         upper: /[lwro]/,
@@ -298,7 +298,7 @@ describe("mockingcase", () => {
       expect(resultOutput).toStrictEqual(expectedOutput);
     });
 
-    test("it should keep string as default since substring does not match", () => {
+    test("Should keep string as default since substring does not match", () => {
       const expectedOutput = "hElLo wOrLd";
       const options = {
         upper: /ohd/,
@@ -312,12 +312,43 @@ describe("mockingcase", () => {
     });
   });
 
+  describe(`option.upper | set as invalid type`, () => {
+    test("Should guarantee throw Error if set as number", () => {
+      const options = {
+        upper: 312313,
+      };
+      const invalidCall = mOcKiNgCaSe.bind(null, 'hello world', options);
+      expect(invalidCall).toThrow();
+    });
+    test("Should guarantee throw Error if set as boolean", () => {
+      const options = {
+        upper: true,
+      };
+      const invalidCall = mOcKiNgCaSe.bind(null, 'hello world', options);
+      expect(invalidCall).toThrow();
+    });
+    test("Should guarantee throw Error if set as array", () => {
+      const options = {
+        upper: ['a', 's', 'g'],
+      };
+      const invalidCall = mOcKiNgCaSe.bind(null, 'hello world', options);
+      expect(invalidCall).toThrow();
+    });
+    test("Should guarantee throw Error if set as dict", () => {
+      const options = {
+        upper: { first: 'a', second: 'b' },
+      };
+      const invalidCall = mOcKiNgCaSe.bind(null, 'hello world', options);
+      expect(invalidCall).toThrow();
+    });
+  });
+
   describe(`option.lower | set as String`, () => {
     const lowerCaseInput = "hello world";
     const capitalizeInput = "Hello World";
     const upperCaseInput = "HELLO WORLD";
 
-    test("it should make match substring lower case", () => {
+    test("Should make match substring lower case", () => {
       const expectedOutput = "hElLo world";
       const options = {
         lower: "WORL",
@@ -330,7 +361,7 @@ describe("mockingcase", () => {
       expect(resultOutput).toStrictEqual(expectedOutput);
     });
 
-    test("it should make matched letters lower case", () => {
+    test("Should make matched letters lower case", () => {
       const expectedOutput = "hEllo world";
       const options = {
         lower: "[LWRO]",
@@ -343,7 +374,7 @@ describe("mockingcase", () => {
       expect(resultOutput).toStrictEqual(expectedOutput);
     });
 
-    test("it should keep string as default since substring does not match", () => {
+    test("Should keep string as default since substring does not match", () => {
       const expectedOutput = "hElLo wOrLd";
       const options = {
         lower: "ohd",
@@ -362,7 +393,7 @@ describe("mockingcase", () => {
     const capitalizeInput = "Hello World";
     const upperCaseInput = "HELLO WORLD";
 
-    test("it should guarantee matched substring is lower case", () => {
+    test("Should guarantee matched substring is lower case", () => {
       const expectedOutput = "hElLo world";
       const options = {
         lower: /WORL/,
@@ -375,7 +406,7 @@ describe("mockingcase", () => {
       expect(resultOutput).toStrictEqual(expectedOutput);
     });
 
-    test("it should guarantee all matched letters are lower case", () => {
+    test("Should guarantee all matched letters are lower case", () => {
       const expectedOutput = "helLo worLd";
       const options = {
         lower: /[OE]/,
@@ -388,7 +419,7 @@ describe("mockingcase", () => {
       expect(resultOutput).toStrictEqual(expectedOutput);
     });
 
-    test("it should keep string as default since substring does not match", () => {
+    test("Should keep string as default since substring does not match", () => {
       const expectedOutput = "hElLo wOrLd";
       const options = {
         lower: /ohd/,
@@ -399,6 +430,37 @@ describe("mockingcase", () => {
       expect(resultOutput).toStrictEqual(expectedOutput);
       resultOutput = mOcKiNgCaSe(upperCaseInput, options);
       expect(resultOutput).toStrictEqual(expectedOutput);
+    });
+  });
+
+  describe(`option.lower | set as invalid type`, () => {
+    test("Should guarantee throw Error if set as number", () => {
+      const options = {
+        lower: 312313,
+      };
+      const invalidCall = mOcKiNgCaSe.bind(null, 'hello world', options);
+      expect(invalidCall).toThrow();
+    });
+    test("Should guarantee throw Error if set as boolean", () => {
+      const options = {
+        lower: true,
+      };
+      const invalidCall = mOcKiNgCaSe.bind(null, 'hello world', options);
+      expect(invalidCall).toThrow();
+    });
+    test("Should guarantee throw Error if set as array", () => {
+      const options = {
+        lower: ['a', 's', 'g'],
+      };
+      const invalidCall = mOcKiNgCaSe.bind(null, 'hello world', options);
+      expect(invalidCall).toThrow();
+    });
+    test("Should guarantee throw Error if set as dict", () => {
+      const options = {
+        lower: { first: 'a', second: 'b' },
+      };
+      const invalidCall = mOcKiNgCaSe.bind(null, 'hello world', options);
+      expect(invalidCall).toThrow();
     });
   });
 });

--- a/mockingcase.test.js
+++ b/mockingcase.test.js
@@ -195,6 +195,7 @@ describe("mockingcase", () => {
       expect(() => mOcKiNgCaSe(input, options)).toThrow(new Error("An input is required"));
     });
   });
+
   describe("overrideConsole", () => {
     test("console.log always prints the mOcKiNgCaSe", () => {
       const input = "hello world";
@@ -218,6 +219,186 @@ describe("mockingcase", () => {
       mOcKiNgCaSe.overrideConsole();
       console.log(input);
       expect(consoleOutput).toEqual(expectedOutput);
+    });
+  });
+
+  describe(`option.upper | set as String`, () => {
+    const lowerCaseInput = "hello world";
+    const capitalizeInput = "Hello World";
+    const upperCaseInput = "HELLO WORLD";
+
+    test("it should make match substring upper case", () => {
+      const expectedOutput = "hElLo WORLd";
+      let options = {
+        upper: "worl"
+      };
+      let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(capitalizeInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(upperCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+    });
+
+    test("it should make matched letters upper case", () => {
+      const expectedOutput = "hELLO WORLd";
+      let options = {
+        upper: "[lwro]"
+      };
+      let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(capitalizeInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(upperCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+    });
+
+    test("it should keep string as default since substring does not match", () => {
+      const expectedOutput = "hElLo wOrLd";
+      let options = {
+        upper: "ohd"
+      };
+      let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(capitalizeInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(upperCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+    });
+  });
+
+  describe(`option.upper | set as RegExp`, () => {
+    const lowerCaseInput = "hello world";
+    const capitalizeInput = "Hello World";
+    const upperCaseInput = "HELLO WORLD";
+
+    test("it should guarantee matched substring is upper case", () => {
+      const expectedOutput = "hElLo WORLd";
+      let options = {
+        upper: /worl/
+      };
+      let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(capitalizeInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(upperCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+    });
+
+    test("it should guarantee all matched letters are upper case", () => {
+      const expectedOutput = "hELLO WORLd";
+      let options = {
+        upper: /[lwro]/
+      };
+      let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(capitalizeInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(upperCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+    });
+
+    test("it should keep string as default since substring does not match", () => {
+      const expectedOutput = "hElLo wOrLd";
+      let options = {
+        upper: /ohd/
+      };
+      let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(capitalizeInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(upperCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+    });
+  });
+
+  describe(`option.lower | set as String`, () => {
+    const lowerCaseInput = "hello world";
+    const capitalizeInput = "Hello World";
+    const upperCaseInput = "HELLO WORLD";
+
+    test("it should make match substring lower case", () => {
+      const expectedOutput = "hElLo world";
+      let options = {
+        lower: "WORL"
+      };
+      let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(capitalizeInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(upperCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+    });
+
+    test("it should make matched letters lower case", () => {
+      const expectedOutput = "hEllo world";
+      let options = {
+        lower: "[LWRO]"
+      };
+      let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(capitalizeInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(upperCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+    });
+
+    test("it should keep string as default since substring does not match", () => {
+      const expectedOutput = "hElLo wOrLd";
+      let options = {
+        lower: "ohd"
+      };
+      let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(capitalizeInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(upperCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+    });
+  });
+
+  describe(`option.lower | set as RegExp`, () => {
+    const lowerCaseInput = "hello world";
+    const capitalizeInput = "Hello World";
+    const upperCaseInput = "HELLO WORLD";
+
+    test("it should guarantee matched substring is lower case", () => {
+      const expectedOutput = "hElLo world";
+      let options = {
+        lower: /WORL/
+      };
+      let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(capitalizeInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(upperCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+    });
+
+    test("it should guarantee all matched letters are lower case", () => {
+      const expectedOutput = "helLo worLd";
+      let options = {
+        lower: /[OE]/
+      };
+      let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(capitalizeInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(upperCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+    });
+
+    test("it should keep string as default since substring does not match", () => {
+      const expectedOutput = "hElLo wOrLd";
+      let options = {
+        lower: /ohd/
+      };
+      let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(capitalizeInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
+      resultOutput = mOcKiNgCaSe(upperCaseInput, options);
+      expect(resultOutput).toStrictEqual(expectedOutput);
     });
   });
 });

--- a/mockingcase.test.js
+++ b/mockingcase.test.js
@@ -313,32 +313,32 @@ describe("mockingcase", () => {
   });
 
   describe(`option.upper | set as invalid type`, () => {
-    test("Should guarantee throw Error if set as number", () => {
+    test("Should throw Error if set as number", () => {
       const options = {
         upper: 312313,
       };
-      const invalidCall = mOcKiNgCaSe.bind(null, 'hello world', options);
+      const invalidCall = mOcKiNgCaSe.bind(null, "hello world", options);
       expect(invalidCall).toThrow();
     });
-    test("Should guarantee throw Error if set as boolean", () => {
+    test("Should throw Error if set as boolean", () => {
       const options = {
         upper: true,
       };
-      const invalidCall = mOcKiNgCaSe.bind(null, 'hello world', options);
+      const invalidCall = mOcKiNgCaSe.bind(null, "hello world", options);
       expect(invalidCall).toThrow();
     });
-    test("Should guarantee throw Error if set as array", () => {
+    test("Should throw Error if set as array", () => {
       const options = {
-        upper: ['a', 's', 'g'],
+        upper: ["a", "s", "g"],
       };
-      const invalidCall = mOcKiNgCaSe.bind(null, 'hello world', options);
+      const invalidCall = mOcKiNgCaSe.bind(null, "hello world", options);
       expect(invalidCall).toThrow();
     });
-    test("Should guarantee throw Error if set as dict", () => {
+    test("Should throw Error if set as dict", () => {
       const options = {
-        upper: { first: 'a', second: 'b' },
+        upper: { first: "a", second: "b" },
       };
-      const invalidCall = mOcKiNgCaSe.bind(null, 'hello world', options);
+      const invalidCall = mOcKiNgCaSe.bind(null, "hello world", options);
       expect(invalidCall).toThrow();
     });
   });
@@ -434,32 +434,32 @@ describe("mockingcase", () => {
   });
 
   describe(`option.lower | set as invalid type`, () => {
-    test("Should guarantee throw Error if set as number", () => {
+    test("Should throw Error if set as number", () => {
       const options = {
         lower: 312313,
       };
-      const invalidCall = mOcKiNgCaSe.bind(null, 'hello world', options);
+      const invalidCall = mOcKiNgCaSe.bind(null, "hello world", options);
       expect(invalidCall).toThrow();
     });
-    test("Should guarantee throw Error if set as boolean", () => {
+    test("Should throw Error if set as boolean", () => {
       const options = {
         lower: true,
       };
-      const invalidCall = mOcKiNgCaSe.bind(null, 'hello world', options);
+      const invalidCall = mOcKiNgCaSe.bind(null, "hello world", options);
       expect(invalidCall).toThrow();
     });
-    test("Should guarantee throw Error if set as array", () => {
+    test("Should throw Error if set as array", () => {
       const options = {
-        lower: ['a', 's', 'g'],
+        lower: ["a", "s", "g"],
       };
-      const invalidCall = mOcKiNgCaSe.bind(null, 'hello world', options);
+      const invalidCall = mOcKiNgCaSe.bind(null, "hello world", options);
       expect(invalidCall).toThrow();
     });
-    test("Should guarantee throw Error if set as dict", () => {
+    test("Should throw Error if set as dict", () => {
       const options = {
-        lower: { first: 'a', second: 'b' },
+        lower: { first: "a", second: "b" },
       };
-      const invalidCall = mOcKiNgCaSe.bind(null, 'hello world', options);
+      const invalidCall = mOcKiNgCaSe.bind(null, "hello world", options);
       expect(invalidCall).toThrow();
     });
   });

--- a/mockingcase.test.js
+++ b/mockingcase.test.js
@@ -229,8 +229,8 @@ describe("mockingcase", () => {
 
     test("it should make match substring upper case", () => {
       const expectedOutput = "hElLo WORLd";
-      let options = {
-        upper: "worl"
+      const options = {
+        upper: "worl",
       };
       let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
       expect(resultOutput).toStrictEqual(expectedOutput);
@@ -242,8 +242,8 @@ describe("mockingcase", () => {
 
     test("it should make matched letters upper case", () => {
       const expectedOutput = "hELLO WORLd";
-      let options = {
-        upper: "[lwro]"
+      const options = {
+        upper: "[lwro]",
       };
       let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
       expect(resultOutput).toStrictEqual(expectedOutput);
@@ -255,8 +255,8 @@ describe("mockingcase", () => {
 
     test("it should keep string as default since substring does not match", () => {
       const expectedOutput = "hElLo wOrLd";
-      let options = {
-        upper: "ohd"
+      const options = {
+        upper: "ohd",
       };
       let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
       expect(resultOutput).toStrictEqual(expectedOutput);
@@ -274,8 +274,8 @@ describe("mockingcase", () => {
 
     test("it should guarantee matched substring is upper case", () => {
       const expectedOutput = "hElLo WORLd";
-      let options = {
-        upper: /worl/
+      const options = {
+        upper: /worl/,
       };
       let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
       expect(resultOutput).toStrictEqual(expectedOutput);
@@ -287,8 +287,8 @@ describe("mockingcase", () => {
 
     test("it should guarantee all matched letters are upper case", () => {
       const expectedOutput = "hELLO WORLd";
-      let options = {
-        upper: /[lwro]/
+      const options = {
+        upper: /[lwro]/,
       };
       let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
       expect(resultOutput).toStrictEqual(expectedOutput);
@@ -300,8 +300,8 @@ describe("mockingcase", () => {
 
     test("it should keep string as default since substring does not match", () => {
       const expectedOutput = "hElLo wOrLd";
-      let options = {
-        upper: /ohd/
+      const options = {
+        upper: /ohd/,
       };
       let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
       expect(resultOutput).toStrictEqual(expectedOutput);
@@ -319,8 +319,8 @@ describe("mockingcase", () => {
 
     test("it should make match substring lower case", () => {
       const expectedOutput = "hElLo world";
-      let options = {
-        lower: "WORL"
+      const options = {
+        lower: "WORL",
       };
       let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
       expect(resultOutput).toStrictEqual(expectedOutput);
@@ -332,8 +332,8 @@ describe("mockingcase", () => {
 
     test("it should make matched letters lower case", () => {
       const expectedOutput = "hEllo world";
-      let options = {
-        lower: "[LWRO]"
+      const options = {
+        lower: "[LWRO]",
       };
       let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
       expect(resultOutput).toStrictEqual(expectedOutput);
@@ -345,8 +345,8 @@ describe("mockingcase", () => {
 
     test("it should keep string as default since substring does not match", () => {
       const expectedOutput = "hElLo wOrLd";
-      let options = {
-        lower: "ohd"
+      const options = {
+        lower: "ohd",
       };
       let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
       expect(resultOutput).toStrictEqual(expectedOutput);
@@ -364,8 +364,8 @@ describe("mockingcase", () => {
 
     test("it should guarantee matched substring is lower case", () => {
       const expectedOutput = "hElLo world";
-      let options = {
-        lower: /WORL/
+      const options = {
+        lower: /WORL/,
       };
       let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
       expect(resultOutput).toStrictEqual(expectedOutput);
@@ -377,8 +377,8 @@ describe("mockingcase", () => {
 
     test("it should guarantee all matched letters are lower case", () => {
       const expectedOutput = "helLo worLd";
-      let options = {
-        lower: /[OE]/
+      const options = {
+        lower: /[OE]/,
       };
       let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
       expect(resultOutput).toStrictEqual(expectedOutput);
@@ -390,8 +390,8 @@ describe("mockingcase", () => {
 
     test("it should keep string as default since substring does not match", () => {
       const expectedOutput = "hElLo wOrLd";
-      let options = {
-        lower: /ohd/
+      const options = {
+        lower: /ohd/,
       };
       let resultOutput = mOcKiNgCaSe(lowerCaseInput, options);
       expect(resultOutput).toStrictEqual(expectedOutput);


### PR DESCRIPTION
### ******* **DO NOT MERGE** *******

There is still a lot to do. But I implemented the function. I also refactor the `convert` function in order to keep the code DRY and implement the 3 bulletin (**If both are present, then don't convert letters that don't much any regex**) 



### TO DO:
* [x]  Add **upper** and **lower** options and implement them.
* [x]  Comment options using jsdoc
* [x]  Add unit test for **upper** and **lower** options
* [x]  Add declaration of **upper** and **lower** options for Typescript, [Declaration Files](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html)
* [x]  Add usage and describe **upper** and **lower** options in README
* [ ] Squash Commits

