### PR TITLE
CDN Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,8 +207,14 @@ Overrides the console.log input annd prints it in the mOcKiNgCaSe.
 
 <hr>
 
-## CDN
-Mockingcase can be served to the browser from a CDN. Simply put `index.js` into your server files or use Mockingcase from a CDN. Some CDNs are provided below:
+## Browser Usage
+mOcKiNgCaSe can be used in a node environment, as well as in the browser. You can serve it yourself, or pull it from a CDN.
+
+### Self Hosting
+To host mOcKiNgCaSe yourself simply put `index.js` wherever your static content (like CSS stylesheets) are kept. You can also download a minified file from one of the CDNs below.
+
+### CDN Usage
+Simply pull in one of the following JS files below.
 
 |Name|Link|
 |-|-|

--- a/README.md
+++ b/README.md
@@ -207,4 +207,12 @@ Overrides the console.log input annd prints it in the mOcKiNgCaSe.
 
 <hr>
 
+## CDN
+Mockingcase can be served to the browser from a CDN. Simply put `index.js` into your server files or use Mockingcase from a CDN. Some CDNs are provided below:
+
+|Name|Link|
+|-|-|
+|unpkg.com|https://unpkg.com/mockingcase/index.js|
+|JSDelivr.com|https://cdn.jsdelivr.net/npm/mockingcase/index.min.js|
+
 **See also [Mockingcase bindings for ReasonML](https://redex.github.io/package/unpublished/strdr4605/bs-mockingcase)**

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ mOcKiNgCaSe('foo bar42', {onlyLetters: false, firstUpper: false});
 - [mOcKiNgCaSe.config(defaultOptions) ⇒ <code>mOcKiNgCaSe</code>](#mOcKiNgCaSe.config)
 - [mOcKiNgCaSe.log(input, [options])](#mOcKiNgCaSe.log)
 - [mOcKiNgCaSe.overrideConsole([options]) ⇒ <code>mOcKiNgCaSe</code>](#mOcKiNgCaSe.overrideConsole)
+- [Browser Usage](#browser-usage)
+  - [Self Hosting](#self-hosting)
+  - [CDN Usage](#cdn-usage)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -208,8 +211,21 @@ Overrides the console.log input annd prints it in the mOcKiNgCaSe.
 <hr>
 
 ## Browser Usage
-mOcKiNgCaSe can be used in a node environment, as well as in the browser. You can serve it yourself, or pull it from a CDN.
-
+mOcKiNgCaSe can be used in a node environment, as well as in the browser. You can serve it yourself, or pull it from a CDN. For example:
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>mOcKiNgCaSe</title>
+</head>
+<body>
+</body>
+<script scr="https://unpkg.com/mockingcase/index.js"></script>
+<script>
+  mOcKiNgCaSe('foo-bar');
+</script>
+</html>
+```
 ### Self Hosting
 To host mOcKiNgCaSe yourself simply put `index.js` wherever your static content (like CSS stylesheets) are kept. You can also download a minified file from one of the CDNs below.
 

--- a/index.js
+++ b/index.js
@@ -148,5 +148,6 @@ function randomCase(input) {
 function convert(input, shouldLetterBeUpperCase) {
   return input.replace(/./g, (str, i) => (shouldLetterBeUpperCase(str, i) ? str.toUpperCase() : str.toLowerCase()));
 }
-
-if (typeof module !== 'undefined') module.exports = mOcKiNgCaSe;
+if (typeof window === 'undefined') {
+  module.exports = mOcKiNgCaSe;
+}

--- a/index.js
+++ b/index.js
@@ -149,4 +149,4 @@ function convert(input, shouldLetterBeUpperCase) {
   return input.replace(/./g, (str, i) => (shouldLetterBeUpperCase(str, i) ? str.toUpperCase() : str.toLowerCase()));
 }
 
-module.exports = mOcKiNgCaSe;
+if (typeof module !== 'undefined') module.exports = mOcKiNgCaSe;

--- a/mockingcase.test.js
+++ b/mockingcase.test.js
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 /* eslint-disable no-shadow */
 /* eslint-disable global-require */
 const mOcKiNgCaSe = require("./index").overrideString();
@@ -191,4 +194,22 @@ describe("mockingcase", () => {
       expect(consoleOutput).toEqual(expectedOutput);
     });
   });
+
+  describe("Browser Tools", () => {
+    test("Should not export module in a browser environment", () => {
+      jest.resetModules()
+
+      global.window = {a: 1};
+      const mod = require('./index.js');
+      expect(typeof mod).not.toBe('function')
+    })
+    test("Should export module in a node environment", () => {
+      jest.resetModules()
+
+      global.window = undefined;
+      const mod = require('./index.js');
+      expect(typeof mod).toBe('function')
+    })
+  })
+
 });


### PR DESCRIPTION
This PR adds support for using Mockingcase over a CDN, and from the browser. 

`index.js` is modified so you can pull it to the browser like this: <script src="http://localhost:9080/index.js"></script>. Documentation for this change is added in `README.md`. 

This PR fixes issue #51 .