### PR TITLE
Changes to README and Change to Way Module is Exported

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,5 +25,7 @@ module.exports = {
     "no-param-reassign": 1,
     "arrow-parens": [2, "as-needed"],
     "prefer-object-spread": 0,
+    "no-param-reassign": 0,
+    "no-unused-vars": 0,
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,10 +22,8 @@ module.exports = {
     quotes: 0,
     "no-use-before-define": 0,
     "no-plusplus": 0,
-    "no-param-reassign": 1,
+    "no-param-reassign": 0,
     "arrow-parens": [2, "as-needed"],
     "prefer-object-spread": 0,
-    "no-param-reassign": 0,
-    "no-unused-vars": 0,
   },
 };

--- a/README.md
+++ b/README.md
@@ -220,9 +220,10 @@ mOcKiNgCaSe can be used in a node environment, as well as in the browser. You ca
 </head>
 <body>
 </body>
-<script scr="https://unpkg.com/mockingcase/index.js"></script>
+<script src="https://unpkg.com/mockingcase/index.js"></script>
 <script>
-  mOcKiNgCaSe('foo-bar');
+  const output = mOcKiNgCaSe('foo-bar');
+  console.log(output);
 </script>
 </html>
 ```

--- a/README.md
+++ b/README.md
@@ -51,45 +51,6 @@ mOcKiNgCaSe('foo', {firstUpper: true, random: true});
 //=> 'FOo'
 //=> 'FoO'
 //=> 'FOO'
-
-mOcKiNgCaSe(['foo','bar']);
-//=> 'fOoBaR'
-
-mOcKiNgCaSe(undefined);
-//=> Error "An input is required"
-
-mOcKiNgCaSe.log('foo bar');
-// console.log('fOo bAr');
-
-// Optionally create String.prototype.toMockingCase
-mOcKiNgCaSe.overrideString();
-
-'foo_bar'.toMockingCase();
-//=> 'fOo_bAr'
-
-'foo_bar'.toMockingCase({firstUpper: true});
-//=> 'FoO_BaR'
-
-// Optionally overrides console.log and returns a mOcKiNgCaSe object
-mOcKiNgCaSe.overrideConsole();
-console.log('Hello');
-//=> 'hElLo'
-
-const mOcKiNgCaSe = require('@strdr4605/mockingcase').overrideConsole();
-console.log('foobar')
-// => 'fOoBaR'
-mOcKiNgCaSe('foobar');
-// => 'fOoBaR'
-
-// Optionally create an initial config with default options
-const mOcKiNgCaSe = require('@strdr4605/mockingcase').config({onlyLetters: true, firstUpper: true});
-// const mOcKiNgCaSe = mOcKiNgCaSe.config({onlyLetters: true, firstUpper: true});
-
-mOcKiNgCaSe('foo bar42');
-//=> 'FoO BaR'
-
-mOcKiNgCaSe('foo bar42', {onlyLetters: false, firstUpper: false});
-//=> 'fOo bAr42'
 ```
 
 ## API
@@ -126,6 +87,43 @@ Converts the input string(s) to mOcKiNgCaSe.
 | options.onlyLetters | <code>boolean</code> | <code>false</code> | If non letters characters should be removed |
 | options.firstUpper | <code>boolean</code> | <code>false</code> | If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with `options.random`, the first letter of the random string will be capitalized |
 
+```js
+mOcKiNgCaSe('foo-bar');
+//=> 'fOo-bAr'
+
+mOcKiNgCaSe('aa', {random: false});
+//=> 'aA'
+
+mOcKiNgCaSe('aa', {random: true});
+//=> 'aa'
+//=> 'aA'
+//=> 'Aa'
+//=> 'AA'
+
+mOcKiNgCaSe('42foo!bar');
+//=> '42fOo!bAr'
+
+mOcKiNgCaSe('aa123', {onlyLetters: true});
+//=> 'aA'
+
+mOcKiNgCaSe('a13%$a', {onlyLetters: true});
+//=> 'aA'
+
+mOcKiNgCaSe('foo bar', {firstUpper: true});
+//=> 'FoO BaR'
+
+mOcKiNgCaSe('foo', {firstUpper: true, random: true});
+//=> 'Foo'
+//=> 'FOo'
+//=> 'FoO'
+//=> 'FOO'
+
+mOcKiNgCaSe(['foo','bar']);
+//=> 'fOoBaR'
+
+mOcKiNgCaSe(undefined);
+//=> Error "An input is required"
+```
 <hr>
 
 <a name="mOcKiNgCaSe.overrideString"></a>
@@ -137,6 +135,15 @@ Creates `String.prototype.toMockingCase()`.
 **Returns**: <code>mOcKiNgCaSe</code> - The mOcKiNgCaSe module.
 **See**: <code>toMockingCase</code>
 
+```js
+mOcKiNgCaSe.overrideString();
+
+'foo_bar'.toMockingCase();
+//=> 'fOo_bAr'
+
+'foo_bar'.toMockingCase({firstUpper: true});
+//=> 'FoO_BaR'
+```
 <hr>
 
 <a name="String.prototype.toMockingCase"></a>
@@ -156,6 +163,13 @@ Converts `this` string to mOcKiNgCaSe.
 | options.onlyLetters | <code>boolean</code> | <code>false</code> | If non letters characters should be removed |
 | options.firstUpper | <code>boolean</code> | <code>false</code> | If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with `options.random`, the first letter of the random string will be capitalized |
 
+```js
+'foo_bar'.toMockingCase();
+//=> 'fOo_bAr'
+
+'foo_bar'.toMockingCase({firstUpper: true});
+//=> 'FoO_BaR'
+```
 <hr>
 
 <a name="mOcKiNgCaSe.config"></a>
@@ -173,6 +187,16 @@ Outputs a mOcKiNgCaSe with default options.
 | defaultOptions.onlyLetters | <code>boolean</code> | <code>false</code> | If non letters characters should be removed |
 | defaultOptions.firstUpper | <code>boolean</code> | <code>false</code> | If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with `options.random`, the first letter of the random string will be capitalized |
 
+```js
+const mOcKiNgCaSe = require('@strdr4605/mockingcase').config({onlyLetters: true, firstUpper: true});
+// const mOcKiNgCaSe = mOcKiNgCaSe.config({onlyLetters: true, firstUpper: true});
+
+mOcKiNgCaSe('foo bar42');
+//=> 'FoO BaR'
+
+mOcKiNgCaSe('foo bar42', {onlyLetters: false, firstUpper: false});
+//=> 'fOo bAr42'
+```
 <hr>
 
 <a name="mOcKiNgCaSe.log"></a>
@@ -190,6 +214,11 @@ Outputs a message to the console in mOcKiNgCaSe.
 | options.onlyLetters | <code>boolean</code> | <code>false</code> | If non letters characters should be removed |
 | options.firstUpper | <code>boolean</code> | <code>false</code> | If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with `options.random`, the first letter of the random string will be capitalized |
 
+```js
+mOcKiNgCaSe.log('foo bar');
+// console.log('fOo bAr');
+```
+
 <a name="mOcKiNgCaSe"></a>
 
 <hr>
@@ -206,6 +235,13 @@ Overrides the console.log input annd prints it in the mOcKiNgCaSe.
 | options.onlyLetters | <code>boolean</code> | <code>false</code> | If non letters characters should be removed |
 | options.firstUpper | <code>boolean</code> | <code>false</code> | If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with `options.random`, the first letter of the random string will be capitalized |
 
+```js
+const mOcKiNgCaSe = require('@strdr4605/mockingcase').overrideConsole();
+console.log('foobar')
+// => 'fOoBaR'
+mOcKiNgCaSe('foobar');
+// => 'fOoBaR'
+```
 <a name="mOcKiNgCaSe"></a>
 
 <hr>

--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ mOcKiNgCaSe can be used in a node environment, as well as in the browser. You ca
 <script>
   const output = mOcKiNgCaSe('foo-bar');
   console.log(output);
+  const output2 = mockingcase('foo-bar');
+  console.log(output2);
 </script>
 </html>
 ```

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+// eslint-disable-next-line no-var
+var mockingcase;
 /**
  * Converts the input string(s) to mOcKiNgCaSe.
  * @param {(string | string[])} input String(s) to be converted.
@@ -148,6 +150,8 @@ function randomCase(input) {
 function convert(input, shouldLetterBeUpperCase) {
   return input.replace(/./g, (str, i) => (shouldLetterBeUpperCase(str, i) ? str.toUpperCase() : str.toLowerCase()));
 }
-if (typeof window === "undefined") {
+mockingcase = mOcKiNgCaSe;
+
+try {
   module.exports = mOcKiNgCaSe;
-}
+} catch (e) {} // eslint-disable-line no-empty

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-// eslint-disable-next-line no-var
-var mockingcase;
 /**
  * Converts the input string(s) to mOcKiNgCaSe.
  * @param {(string | string[])} input String(s) to be converted.
@@ -150,7 +148,8 @@ function randomCase(input) {
 function convert(input, shouldLetterBeUpperCase) {
   return input.replace(/./g, (str, i) => (shouldLetterBeUpperCase(str, i) ? str.toUpperCase() : str.toLowerCase()));
 }
-mockingcase = mOcKiNgCaSe;
+
+const mockingcase = mOcKiNgCaSe; // eslint-disable-line no-unused-vars
 
 try {
   module.exports = mOcKiNgCaSe;

--- a/mockingcase.test.js
+++ b/mockingcase.test.js
@@ -220,21 +220,4 @@ describe("mockingcase", () => {
       expect(consoleOutput).toEqual(expectedOutput);
     });
   });
-
-  describe("Browser Tools", () => {
-    test("Should not export module in a browser environment", () => {
-      jest.resetModules();
-
-      global.window = { a: 1 };
-      const mod = require("./index.js");
-      expect(typeof mod).not.toBe("function");
-    });
-    test("Should export module in a node environment", () => {
-      jest.resetModules();
-
-      global.window = undefined;
-      const mod = require("./index.js");
-      expect(typeof mod).toBe("function");
-    });
-  });
 });


### PR DESCRIPTION
In this PR, I have made the proposed changes to the `README.md` that was proposed in #55. I have cut out a large portion of the main `Usage` section and have created a small example under each method in the API, taken from the `Usage` section. A live version can be viewed here: https://github.com/maxrumsey/mockingcase/blob/8c8d727aa4ef07e94edce8af03dfbb7ddb195a68/README.md.

I have also changed the way the module is exported. Instead of this:
```js
if (typeof window === 'undefined') {
    module.exports = mOcKiNgCaSe;
}
```
it is now this:
```js
try {
    module.exports = mOcKiNgCaSe;
} catch (e) {}
```
The reason I changed this is because the module won't correctly export itself if there is any global variable named 'window.' This especially causes an issue when in use with the `Electron` library, as it injects a `window` object into the global namespace, so our module wouldn't be able to be required anywhere within an electron app.

I have also added a line:
```js
var mockingcase = mOcKiNgCaSe;
```
This allows users to reference the `mOcKiNgCaSe` function as `mockingcase` to reduce the chance of ReferenceErrors.