### PR TITLE
Close #83 add typedef for options, refactor jsdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ mockingcase('ABCDEF', {lower: 'bcd'});
 - [mockingcase.config(defaultOptions) ⇒ <code>mockingcase</code>](#mockingcase.config)
 - [mockingcase.log(input, [options])](#mockingcase.log)
 - [mockingcase.overrideConsole([options]) ⇒ <code>mockingcase</code>](#mockingcase.overrideConsole)
+- [Options](#Options)
 - [Browser Usage](#mockingcase.browserUsage)
 
 ## Functions
@@ -260,7 +261,7 @@ mockingcase('foobar');
 
 <a name="Options"></a>
 
-## Options : <code>Object</code>
+## Options : <code>Object</code> [:arrow_up:](#api)
 Options for mockingcase
 
 **Kind**: global typedef

--- a/README.md
+++ b/README.md
@@ -73,9 +73,25 @@ mockingcase('ABCDEF', {lower: 'bcd'});
 - [mockingcase.overrideConsole([options]) ⇒ <code>mockingcase</code>](#mockingcase.overrideConsole)
 - [Browser Usage](#mockingcase.browserUsage)
 
+## Functions
+
+<dl>
+<dt><a href="#mockingcase">mockingcase(input, [options])</a> ⇒ <code>string</code></dt>
+<dd><p>Converts the input string(s) to mOcKiNgCaSe.</p>
+</dd>
+</dl>
+
+## Typedefs
+
+<dl>
+<dt><a href="#Options">Options</a> : <code>Object</code></dt>
+<dd><p>Options for mockingcase</p>
+</dd>
+</dl>
+
 <a name="mockingcase"></a>
 
-### mockingcase(input, [options]) ⇒ <code>string</code> [:arrow_up:](#api)
+## mockingcase(input, [options]) ⇒ <code>string</code> [:arrow_up:](#api)
 Converts the input string(s) to mOcKiNgCaSe.
 
 **Kind**: global function
@@ -83,13 +99,8 @@ Converts the input string(s) to mOcKiNgCaSe.
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| input | <code>string</code> \| <code>string[]</code> |  | String(s) to be converted |
-| [options] | <code>object</code> | <code>{random: false, onlyLetters: false, firstUpper: false}</code> | Conversion options |
-| options.random | <code>boolean</code> | <code>false</code> | If case conversion should be randomized |
-| options.onlyLetters | <code>boolean</code> | <code>false</code> | If non letters characters should be removed |
-| options.firstUpper | <code>boolean</code> | <code>false</code> | If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with `options.random`, the first letter of the random string will be capitalized |
-| options.upper | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to uppercase |
-| options.lower | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to lowercase |
+| input | <code>string</code> \| <code>Array.&lt;string&gt;</code> |  | String(s) to be converted. |
+| [options] | [<code>Options</code>](#Options) | <code>{random: false,  onlyLetters: false, firstUpper: false, upper: null, lower: null}</code> | Conversion options. |
 
 ```js
 mockingcase('foo-bar');
@@ -141,9 +152,8 @@ mockingcase(undefined);
 ### mockingcase.overrideString() ⇒ <code>mockingcase</code> [:arrow_up:](#api)
 Creates `String.prototype.toMockingCase()`.
 
-**Kind**: global function
-**Returns**: <code>mockingcase</code> - The mockingcase module.
-**See**: <code>toMockingCase</code>
+**Kind**: static method of [<code>mockingcase</code>](#mockingcase)
+**Returns**: mockingcase
 
 ```js
 mockingcase.overrideString();
@@ -168,12 +178,8 @@ Converts `this` string to mOcKiNgCaSe.
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| [options] | <code>object</code> | <code>{random: false, onlyLetters: false, firstUpper: false}</code> | Conversion options |
-| options.random | <code>boolean</code> | <code>false</code> | If case conversion should be randomized |
-| options.onlyLetters | <code>boolean</code> | <code>false</code> | If non letters characters should be removed |
-| options.firstUpper | <code>boolean</code> | <code>false</code> | If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with `options.random`, the first letter of the random string will be capitalized |
-| options.upper | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to uppercase |
-| options.lower | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to lowercase |
+| input | <code>string</code> \| <code>Array.&lt;string&gt;</code> |  | String(S) to be converted. |
+| [options] | [<code>Options</code>](#Options) | <code>{random: false,  onlyLetters: false, firstUpper: false, upper: null, lower: null}</code> | Conversion options. |
 
 ```js
 'foo_bar'.toMockingCase();
@@ -187,19 +193,15 @@ Converts `this` string to mOcKiNgCaSe.
 <a name="mockingcase.config"></a>
 
 ### mockingcase.config(defaultOptions) ⇒ <code>mockingcase</code> [:arrow_up:](#api)
-Outputs a mOcKiNgCaSe with default options.
+Outputs a mockingcase with default options.
 
 **Kind**: static method of [<code>mockingcase</code>](#mockingcase)
 **Returns**: mockingcase with default options
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| defaultOptions | <code>object</code> |  | Options for converting |
-| defaultOptions.random | <code>boolean</code> | <code>false</code> | If case conversion should be randomized |
-| defaultOptions.onlyLetters | <code>boolean</code> | <code>false</code> | If non letters characters should be removed |
-| defaultOptions.firstUpper | <code>boolean</code> | <code>false</code> | If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with `options.random`, the first letter of the random string will be capitalized |
-| options.upper | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to uppercase |
-| options.lower | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to lowercase |
+| defaultOptions | [<code>Options</code>](#Options) | <code>{random: false,  onlyLetters: false, firstUpper: false, upper: null, lower: null}</code> | Conversion options. |
+
 
 ```js
 const mockingcase = require('@strdr4605/mockingcase').config({onlyLetters: true, firstUpper: true});
@@ -222,13 +224,8 @@ Outputs a message to the console in mOcKiNgCaSe.
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| input | <code>string</code> \| <code>string[]</code> |  | String(S) to be converted |
-| [options] | <code>object</code> | <code>{random: false, onlyLetters: false, firstUpper: false}</code> | Conversion options |
-| options.random | <code>boolean</code> | <code>false</code> | If case conversion should be randomized |
-| options.onlyLetters | <code>boolean</code> | <code>false</code> | If non letters characters should be removed |
-| options.firstUpper | <code>boolean</code> | <code>false</code> | If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with `options.random`, the first letter of the random string will be capitalized |
-| options.upper | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to uppercase |
-| options.lower | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to lowercase |
+| input | <code>string</code> \| <code>Array.&lt;string&gt;</code> |  | String(S) to be converted. |
+| [options] | [<code>Options</code>](#Options) | <code>{random: false,  onlyLetters: false, firstUpper: false, upper: null, lower: null}</code> | Conversion options. |
 
 ```js
 mockingcase.log('foo bar');
@@ -242,16 +239,15 @@ mockingcase.log('foo bar');
 <a name="mockingcase.overrideConsole"></a>
 
 ### mockingcase.overrideConsole([options]) ⇒ <code>mockingcase</code> [:arrow_up:](#api)
-Overrides the console.log input annd prints it in the mOcKiNgCaSe.
+Overrides console.log input to print the input mOcKiNgCaSe.
+
+**Kind**: static method of [<code>mockingcase</code>](#mockingcase)
+**Returns**: <code>function</code> - mockingcase function
+**See**: mockingcase
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
-| [options] | <code>object</code> | <code>{random: false, onlyLetters: false, firstUpper: false}</code> | Conversion options |
-| options.random | <code>boolean</code> | <code>false</code> | If case conversion should be randomized |
-| options.onlyLetters | <code>boolean</code> | <code>false</code> | If non letters characters should be removed |
-| options.firstUpper | <code>boolean</code> | <code>false</code> | If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with `options.random`, the first letter of the random string will be capitalized |
-| options.upper | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to uppercase |
-| options.lower | <code>RegExp</code> \| <code>string</code> | <code>null</code> | Characters or substring set to change to lowercase |
+| [options] | [<code>Options</code>](#Options) | <code>{random: false,  onlyLetters: false, firstUpper: false, upper: null, lower: null}</code> | Conversion options. |
 
 ```js
 const mockingcase = require('@strdr4605/mockingcase').overrideConsole();
@@ -260,6 +256,24 @@ console.log('foobar')
 mockingcase('foobar');
 // => 'fOoBaR'
 ```
+<hr>
+
+<a name="Options"></a>
+
+## Options : <code>Object</code>
+Options for mockingcase
+
+**Kind**: global typedef
+**Properties**
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| [random] | <code>boolean</code> | <code>false</code> | If case conversion should be randomized. |
+| [onlyLetters] | <code>boolean</code> | <code>false</code> | If non letters characters should be removed. |
+| [firstUpper] | <code>boolean</code> | <code>false</code> | If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with options.random, the first letter of the random string will be capitalized. |
+| [upper] | <code>string</code> \| <code>RegExp</code> | <code>null</code> | Characters or substring set to change to uppercase, `upper` has higher priority that `lower`. |
+| [lower] | <code>string</code> \| <code>RegExp</code> | <code>null</code> | Characters or substring set to change to lowercase. |
+
 <hr>
 
 <a name="mockingcase.browserUsage"></a>

--- a/src/mockingcase.d.ts
+++ b/src/mockingcase.d.ts
@@ -2,7 +2,7 @@
 // Project: https://github.com/strdr4605/mockingcase
 // Definitions by: Dragoș Străinu https://github.com/strdr4605
 
-declare module "mockingcase" {
+declare module "@strdr4605/mockingcase" {
   interface Options {
     random?: boolean;
     onlyLetters?: boolean;

--- a/src/mockingcase.js
+++ b/src/mockingcase.js
@@ -1,14 +1,21 @@
 /**
+ * Options for mockingcase.
+ * @typedef {Object} Options
+ * @property {boolean} [random=false] - If case conversion should be randomized.
+ * @property {boolean} [onlyLetters=false] - If non letters characters should be removed.
+ * @property {boolean} [firstUpper=false] - If the first letter should be capitalized
+ * instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE).
+ * When combined with options.random, the first letter of the random string will be capitalized.
+ * @property {(string | RegExp)} [upper=null] - Characters or substring set to change to uppercase,
+ * `upper` has higher priority that `lower`.
+ * @property {(string | RegExp)} [lower=null] - Characters or substring set to change to lowercase.
+ */
+
+/**
  * Converts the input string(s) to mOcKiNgCaSe.
- * @param {(string | string[])} input String(s) to be converted.
- * @param {object} [options={random: false,  onlyLetters: false, firstUpper: false, upper: null, lower: null}] Conversion options.
- * @param {boolean} options.random=false - If case conversion should be randomized.
- * @param {boolean} options.onlyLetters=false - If non letters characters should be removed.
- * @param {boolean} options.firstUpper=false - If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with options.random, the first letter of the random string will be capitalized.
- * @param {(string | RegExp)} options.upper=null - Characters or substring set to change to uppercase
- * @param {(string | RegExp)} options.lower=null - Characters or substring set to change to lowercase
- * When combined with `options.random`, the first letter of the random string will be capitalized.
- * @returns {string} string in mOcKiNgCaSe
+ * @param {(string | string[])} input - String(s) to be converted.
+ * @param {Options} [options={random: false, onlyLetters: false, firstUpper: false, upper: null, lower: null}] - Conversion options.
+ * @returns {string} string in mOcKiNgCaSe.
  */
 function mockingcase(input = "", options) {
   options = Object.assign(
@@ -44,10 +51,10 @@ function mockingcase(input = "", options) {
       input = input[0].toUpperCase() + input.slice(1);
     }
   } else if (options.firstUpper) {
-    input = convert(input, (str, i) => i % 2 === 0);
+    input = convert(input, (_str, i) => i % 2 === 0);
   } else {
     // Default to making the odd positioned characters upper case
-    input = convert(input, (str, i) => i % 2 === 1);
+    input = convert(input, (_str, i) => i % 2 === 1);
   }
 
   if (options.lower) {
@@ -63,24 +70,15 @@ function mockingcase(input = "", options) {
 
 /**
  * Outputs a message to the console in mOcKiNgCaSe.
- * @param {(string | string[])} input String(S) to be converted.
- * @param {object} [options={random: false, onlyLetters: false, firstUpper: false, upper: null, lower: null}] Conversion options
- * @param {boolean} options.random=false - If case conversion should be randomized.
- * @param {boolean} options.onlyLetters=false - If non letters characters should be removed.
- * @param {boolean} options.firstUpper=false - If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with options.random, the first letter of the random string will be capitalized.
- * @param {(string | RegExp)} options.upper=null - Characters or substring set to change to uppercase
- * @param {(string | RegExp)} options.lower=null - Characters or substring set to change to lowercase
- * When combined with `options.random`, the first letter of the random string will be capitalized.
+ * @param {(string | string[])} input - String(S) to be converted.
+ * @param {Options} [options={random: false, onlyLetters: false, firstUpper: false, upper: null, lower: null}] - Conversion options.
  */
 mockingcase.log = (input, options) => console.log(mockingcase(input, options));
 
 /**
  * Outputs a mockingcase with default options.
- * @param {object} defaultOptions Options for converting.
- * @param {boolean} defaultOptions.random=false - If case conversion should be randomized.
- * @param {boolean} defaultOptions.onlyLetters=false - If non letters characters should be removed.
- * @param {boolean} defaultOptions.firstUpper=false - If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). * @returns {string} string in mOcKiNgCaSe
- * @return mockingcase with default options
+ * @param {Options} [defaultOptions={random: false, onlyLetters: false, firstUpper: false, upper: null, lower: null}] - Conversion options.
+ * @returns mockingcase with default options
  */
 mockingcase.config = defaultOptions => (input = "", overridedDefaultOptions) => {
   const options = Object.assign(defaultOptions || {}, overridedDefaultOptions || {});
@@ -89,19 +87,13 @@ mockingcase.config = defaultOptions => (input = "", overridedDefaultOptions) => 
 
 /**
  * Creates `String.prototype.toMockingCase()`.
- * @return mockingcase
+ * @returns mockingcase
  */
 mockingcase.overrideString = () => {
   /**
    * Converts this string to mOcKiNgCaSe.
-   * @param {object} [options={random: false, onlyLetters: false, firstUpper: false, upper: null, lower: null}] Options for converting.
-   * @param {boolean} options.random=false - If case conversion should be randomized.
-   * @param {boolean} options.onlyLetters=false - If non letters characters should be removed.
-   * @param {boolean} options.firstUpper=false - If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with options.random, the first letter of the random string will be capitalized.
-   * @param {(string | RegExp)} options.upper=null - Characters or substring set to change to uppercase
-   * @param {(string | RegExp)} options.lower=null - Characters or substring set to change to lowercase
-   * When combined with `options.random`, the first letter of the random string will be capitalized.
-   * @returns {string} string in mOcKiNgCaSe
+   * @param {Options} [options={random: false, onlyLetters: false, firstUpper: false, upper: null, lower: null}] Conversion options.
+   * @returns {string} The string in mOcKiNgCaSe
    * @see mockingcase
    */
   String.prototype.toMockingCase = function toMockingCase(options) {
@@ -113,13 +105,7 @@ mockingcase.overrideString = () => {
 
 /**
  * Overrides console.log input to print the input mOcKiNgCaSe.
- * @param {object} [options={random: false, onlyLetters: false, firstUpper: false, upper: null, lower: null}] Options for converting.
- * @param {boolean} options.random=false - If case conversion should be randomized.
- * @param {boolean} options.onlyLetters=false - If non letters characters should be removed.
- * @param {boolean} options.firstUpper=false - If the first letter should be capitalized instead of the second when converting to mOcKiNgCaSe (e.g. MoCkInGcAsE). When combined with options.random, the first letter of the random string will be capitalized.
- * @param {(string | RegExp)} options.upper=null - Characters or substring set to change to uppercase
- * @param {(string | RegExp)} options.lower=null - Characters or substring set to change to lowercase
- * When combined with `options.random`, the first letter of the random string will be capitalized.
+ * @param {Options} [options={random: false, onlyLetters: false, firstUpper: false, upper: null, lower: null}] Conversion options.
  * @returns {function} mockingcase function
  * @see mockingcase
  */
@@ -133,7 +119,8 @@ mockingcase.overrideConsole = (options = {}) => {
 
 /**
  * @param {string|string[]} input The user-given input.
- * @return If the given input is an array of strings.
+ * @private
+ * @returns {boolean} If the given input is an array of strings.
  */
 function isArrayOfStrings(input) {
   if (!Array.isArray(input)) {
@@ -150,8 +137,9 @@ function isArrayOfStrings(input) {
 }
 
 /**
- * @param {string} input The string to convert.
- * @return The given string with random casings.
+ * @param {string} input-  The string to convert.
+ * @private
+ * @returns The given string with random casings.
  */
 function randomCase(input) {
   return convert(input, () => Math.round(Math.random()));
@@ -159,10 +147,11 @@ function randomCase(input) {
 
 /**
  * Converts matched letters to a specified case
- * @param {string} input - string to convert
- * @param {(string | RegExp)} regex - use to match letters you want to convert
- * @param {function} caseReplacer - a function that changes the letter's case
- * @return {string} given input with match letters to the  case type determined
+ * @param {string} input - The string to convert.
+ * @param {(string | RegExp)} regex - Use to match letters you want to convert.
+ * @param {function} caseReplacer - A function that changes the letter's case.
+ * @private
+ * @returns {string} Given input with match letters to the  case type determined
  */
 function convertToSpecificCase(input, regex, caseReplacer) {
   if (typeof regex !== "string" && !(regex instanceof RegExp)) {
@@ -174,10 +163,11 @@ function convertToSpecificCase(input, regex, caseReplacer) {
 
 /**
  * Converts the string.
- * @param {string} input The string to convert.
- * @param {function(string, number)} shouldLetterBeUpperCase A function given a character and its index,
+ * @param {string} input - The string to convert.
+ * @param {function(string, number)} shouldLetterBeUpperCase -  A function given a character and its index,
  * which returns if the given letter should be set to uppercase. If false, the letter will be lowercase.
- * @return The converted string.
+ * @private
+ * @returns The converted string.
  */
 function convert(input, shouldLetterBeUpperCase) {
   return input.replace(/./g, (str, i) => (shouldLetterBeUpperCase(str, i) ? str.toUpperCase() : str.toLowerCase()));


### PR DESCRIPTION
## Description

A new typedef for options was added. Some small refactoring of jsdocs.
Also fixed module name for typescript type definitions.

Fixes #83 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
